### PR TITLE
마커들의 중심으로 클러스터링 하는 옵션 추가

### DIFF
--- a/marker-clustering/src/MarkerClustering.js
+++ b/marker-clustering/src/MarkerClustering.js
@@ -738,7 +738,7 @@ Cluster.prototype = {
 		averageCenter[0] /= numberOfMarkers;
 		averageCenter[1] /= numberOfMarkers;
 
-		return new naver.maps.Point(averageCenter[1], averageCenter[0]);
+		return new naver.maps.Point(averageCenter[0], averageCenter[1]);
 	}
 
 

--- a/marker-clustering/src/MarkerClustering.js
+++ b/marker-clustering/src/MarkerClustering.js
@@ -250,6 +250,22 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
 		this.setOptions('disableClickZoom', flag);
 	},
 
+	/**
+	 * 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부를 반환합니다.
+	 * @return {boolean} 평균 좌표로 클러스터링 여부
+	 */
+	getAverageCenter: function() {
+		return this.getOptions('averageCenter');
+	},
+
+	/**
+	 * 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부를 설정합니다.
+	 * @param {boolean} averageCenter 평균 좌표로 클러스터링 여부
+	 */
+	setAverageCenter: function(averageCenter) {
+		this.setOptions('averageCenter', averageCenter);
+	},
+
 	// KVO 이벤트 핸들러
 	changed: function(key, value) {
 		if (!this.getMap()) return;
@@ -258,6 +274,7 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
 			case 'marker':
 			case 'minClusterSize':
 			case 'gridSize':
+			case 'averageCenter':
 				this._redraw();
 				break;
 			case 'indexGenerator':
@@ -528,8 +545,8 @@ Cluster.prototype = {
 		if (!this._clusterMarker) {
 			var position;
 
-			if (this._markerClusterer.getOptions().averageCenter) {
-				position = this._getAverageCenter(this._clusterMember);
+			if (this._markerClusterer.getAverageCenter()) {
+				position = this._calcAverageCenter(this._clusterMember);
 			} else {
 				position = this._clusterCenter;
 			}
@@ -697,11 +714,11 @@ Cluster.prototype = {
 
 	/**
 	 * 전달된 마커들의 중심 좌표를 반환합니다.
-	 * @param {Array <naver.maps.Marker>} markers 마커 배열
+	 * @param {Array.<naver.maps.Marker>} markers 마커 배열
 	 * @return {naver.maps.LatLng} 마커들의 중심 좌표
 	 * @private
 	 */
-	_getAverageCenter: function(markers) {
+	_calcAverageCenter: function(markers) {
 		var numberOfMarkers = markers.length;
 		var averageCenter = [0, 0];
 		
@@ -715,4 +732,6 @@ Cluster.prototype = {
 
 		return new naver.maps.LatLng(averageCenter[1], averageCenter[0]);
 	}
+
+
 };

--- a/marker-clustering/src/MarkerClustering.js
+++ b/marker-clustering/src/MarkerClustering.js
@@ -723,7 +723,7 @@ Cluster.prototype = {
 	/**
 	 * 전달된 마커들의 중심 좌표를 반환합니다.
 	 * @param {Array.<naver.maps.Marker>} markers 마커 배열
-	 * @return {naver.maps.LatLng} 마커들의 중심 좌표
+	 * @return {naver.maps.Point} 마커들의 중심 좌표
 	 * @private
 	 */
 	_calcAverageCenter: function(markers) {
@@ -738,7 +738,7 @@ Cluster.prototype = {
 		averageCenter[0] /= numberOfMarkers;
 		averageCenter[1] /= numberOfMarkers;
 
-		return new naver.maps.LatLng(averageCenter[1], averageCenter[0]);
+		return new naver.maps.Point(averageCenter[1], averageCenter[0]);
 	}
 
 

--- a/marker-clustering/src/MarkerClustering.js
+++ b/marker-clustering/src/MarkerClustering.js
@@ -37,6 +37,8 @@ var MarkerClustering = function(options) {
 		icons: [],
 		// 클러스터 마커의 아이콘 배열에서 어떤 아이콘을 선택할 것인지 인덱스를 결정합니다.
 		indexGenerator: [10, 100, 200, 500, 1000],
+		// 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부입니다.
+		averageCenter: false,
 		// 클러스터 마커를 갱신할 때 호출하는 콜백함수입니다. 이 함수를 통해 클러스터 마커에 개수를 표현하는 등의 엘리먼트를 조작할 수 있습니다.
 		stylingFunction: function() {}
 	};
@@ -524,8 +526,16 @@ Cluster.prototype = {
 	 */
 	updateCluster: function() {
 		if (!this._clusterMarker) {
+			var position;
+
+			if (this._markerClusterer.getOptions().averageCenter) {
+				position = this._getAverageCenter(this._clusterMember);
+			} else {
+				position = this._clusterCenter;
+			}
+
 			this._clusterMarker = new naver.maps.Marker({
-				position: this._clusterCenter,
+				position: position,
 				map: this._markerClusterer.getMap()
 			});
 
@@ -683,5 +693,26 @@ Cluster.prototype = {
 	 */
 	_isMember: function(marker) {
 		return this._clusterMember.indexOf(marker) !== -1;
+	},
+
+	/**
+	 * 전달된 마커들의 중심 좌표를 반환합니다.
+	 * @param {Array <naver.maps.Marker>} markers 마커 배열
+	 * @return {naver.maps.LatLng} 마커들의 중심 좌표
+	 * @private
+	 */
+	_getAverageCenter: function(markers) {
+		var numberOfMarkers = markers.length;
+		var averageCenter = [0, 0];
+		
+		for (var i = 0; i < numberOfMarkers; i++) {
+			averageCenter[0] += markers[i].position.x;
+			averageCenter[1] += markers[i].position.y;
+		}
+
+		averageCenter[0] /= numberOfMarkers;
+		averageCenter[1] /= numberOfMarkers;
+
+		return new naver.maps.LatLng(averageCenter[1], averageCenter[0]);
 	}
 };


### PR DESCRIPTION
안녕하세요,

마커 클러스터링 옵션 중 위치에 관한 기능입니다.
기존에는 존재하는 마커의 위치 중 하나로 클러스터링이 되고 있는데요, averageCenter: true 옵션 설정 시, 마커들의 중심으로 클러스터링 되도록 하였습니다.